### PR TITLE
Smart search edits - not always alphabetical now

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import { SchedulePanel } from "@/components/schedule-panel"
 import { supabase } from "@/lib/supabaseClient"
 
 import { getEvents } from "@/app/api/events"
-import { eventMatchesSearch } from "@/lib/searchUtils"
+import { rankedEventMatchesSearch } from "@/lib/searchUtils"
 
 export interface Event {
   id: string
@@ -49,12 +49,12 @@ export default function PicnicDayPage() {
   loadEvents()
 }, [])
 
-  const filteredEvents = events.filter(event => {
-    const matchesSearch = eventMatchesSearch(event, searchQuery)
-    const matchesCategory = selectedCategories.length === 0 ||
+  const searchRanked = rankedEventMatchesSearch(events, searchQuery)
+  const filteredEvents = searchRanked.filter(
+    (event) =>
+      selectedCategories.length === 0 ||
       selectedCategories.includes(event.category)
-    return matchesSearch && matchesCategory
-  })
+  )
 
   const addToSchedule = useCallback((event: Event) => {
     setScheduledEvents(prev => {

--- a/lib/searchUtils.ts
+++ b/lib/searchUtils.ts
@@ -1,6 +1,6 @@
 /**
- * Search utilities: synonyms, related terms ("insects" → bugs, butterflies),
- * and fuzzy matching for spelling errors ("doxy" ↔ "doxie").
+ * Search utilities: ranked matching with exact > substring > synonym > fuzzy (typos).
+ * Synonyms and related terms expand the query; fuzzy is tightened to reduce overmatching.
  */
 
 /** Levenshtein edit distance between two strings */
@@ -25,9 +25,21 @@ function levenshtein(a: string, b: string): number {
   return dp[an][bn];
 }
 
-/** Max edit distance for fuzzy match: 1 for short words, 2 for longer */
-function maxEditDistance(word: string): number {
-  return word.length <= 4 ? 1 : 2;
+/** Stricter fuzzy: 1 edit for short words; 2 edits only when lengths are close (typos, not unrelated). */
+function maxEditDistance(queryWord: string, textWord: string): number {
+  const qLen = queryWord.length;
+  const tLen = textWord.length;
+  const lenDiff = Math.abs(qLen - tLen);
+  if (qLen <= 4 || tLen <= 4) return lenDiff <= 1 ? 1 : 0;
+  if (lenDiff > 2) return 0; // avoid matching very different lengths
+  return qLen <= 7 ? 2 : 1;
+}
+
+/** True if textWord is within allowed edit distance of queryWord (for typos only). */
+function fuzzyMatchWord(queryWord: string, textWord: string): boolean {
+  if (queryWord.length < 2 || textWord.length < 2) return queryWord === textWord;
+  const maxDist = maxEditDistance(queryWord, textWord);
+  return maxDist >= 0 && levenshtein(queryWord, textWord) <= maxDist;
 }
 
 /** Synonyms and related terms (query term → alternatives to also match) */
@@ -82,7 +94,12 @@ function toWords(text: string): string[] {
     .filter((w) => w.length > 0);
 }
 
-/** Expand query into all terms to match: query words + synonyms + related */
+/** Original query words only (normalized, no synonym expansion). */
+function getQueryWords(query: string): string[] {
+  return toWords(query.trim());
+}
+
+/** Expand query into all terms to match: query words + synonyms + related. */
 function getSearchTerms(query: string): string[] {
   const q = query.trim().toLowerCase();
   if (!q) return [];
@@ -96,26 +113,81 @@ function getSearchTerms(query: string): string[] {
   return Array.from(terms);
 }
 
-/** True if `word` is within allowed edit distance of `queryWord` */
-function fuzzyMatchWord(queryWord: string, word: string): boolean {
-  if (queryWord.length < 2 || word.length < 2) return queryWord === word;
-  const maxDist = maxEditDistance(queryWord);
-  return levenshtein(queryWord, word) <= maxDist;
+/** Match tier: 1 = best (exact), 4 = weakest (fuzzy only). */
+export type MatchTier = 1 | 2 | 3 | 4;
+
+export interface RankedMatch<T extends SearchableEvent = SearchableEvent> {
+  event: T;
+  tier: MatchTier;
+  /** Higher = better within same tier (e.g. more substring matches). */
+  tiebreaker: number;
 }
 
-/** Check if any of the search terms (or fuzzy match) appears in text */
-function textMatchesTerms(text: string, searchTerms: string[]): boolean {
-  const lower = text.toLowerCase();
-  const textWords = toWords(text);
+/**
+ * Computes the best match tier and tiebreaker for one event.
+ * Tier 1: exact phrase or exact event name match.
+ * Tier 2: substring match of original query words.
+ * Tier 3: substring match of synonym/related terms only.
+ * Tier 4: fuzzy (typo) match of query words only.
+ */
+function scoreEvent<T extends SearchableEvent>(event: T, query: string): RankedMatch<T> | null {
+  const q = query.trim();
+  if (!q) return { event, tier: 1, tiebreaker: 0 };
 
-  for (const term of searchTerms) {
+  const combined = [event.name, event.description, event.location].join(" ").toLowerCase();
+  const combinedNorm = [event.name, event.description, event.location]
+    .map((s) => s.toLowerCase().replace(/\s+/g, " ").trim())
+    .join(" ");
+  const queryLower = q.toLowerCase();
+  const queryWords = getQueryWords(q);
+  const searchTerms = getSearchTerms(q);
+  const textWords = toWords(combined);
+
+  const queryWordsSet = new Set(queryWords);
+  /** Synonym-only terms (not the original query words). */
+  const synonymTerms = searchTerms.filter((t) => !queryWordsSet.has(t));
+
+  // Tier 1: exact phrase or exact event name
+  if (combinedNorm.includes(queryLower) || toWords(event.name).join(" ") === toWords(q).join(" ")) {
+    return { event, tier: 1, tiebreaker: 1 };
+  }
+
+  // Tier 2: substring match of original query words
+  let substringCount = 0;
+  for (const w of queryWords) {
+    if (w.length < 2) continue;
+    if (combined.includes(w)) substringCount++;
+  }
+  if (substringCount > 0) {
+    return { event, tier: 2, tiebreaker: substringCount };
+  }
+
+  // Tier 3: synonym/related term as exact substring (no fuzzy)
+  let synonymCount = 0;
+  for (const term of synonymTerms) {
     if (term.length < 2) continue;
-    if (lower.includes(term)) return true;
-    for (const textWord of textWords) {
-      if (fuzzyMatchWord(term, textWord)) return true;
+    if (combined.includes(term)) synonymCount++;
+  }
+  if (synonymCount > 0) {
+    return { event, tier: 3, tiebreaker: synonymCount };
+  }
+
+  // Tier 4: fuzzy match of query words only (typos)
+  let fuzzyCount = 0;
+  for (const qw of queryWords) {
+    if (qw.length < 2) continue;
+    for (const tw of textWords) {
+      if (fuzzyMatchWord(qw, tw)) {
+        fuzzyCount++;
+        break;
+      }
     }
   }
-  return false;
+  if (fuzzyCount > 0) {
+    return { event, tier: 4, tiebreaker: fuzzyCount };
+  }
+
+  return null;
 }
 
 export interface SearchableEvent {
@@ -125,26 +197,37 @@ export interface SearchableEvent {
 }
 
 /**
- * Returns true if the event matches the search query using:
- * - Exact substring match
- * - Synonyms and related terms (e.g. "dog racing" ↔ "canine", "race")
- * - Fuzzy spelling (e.g. "doxy" ↔ "doxie")
+ * Returns events that match the search query, sorted by relevance.
+ * Order: exact phrase/name (1) > substring (2) > synonym (3) > fuzzy/typo (4).
+ * Fuzzy matching is restricted to similar-length words to reduce overmatching.
+ * Preserves input type (e.g. Event[] in → Event[] out).
+ */
+export function rankedEventMatchesSearch<T extends SearchableEvent>(
+  events: T[],
+  searchQuery: string
+): T[] {
+  const q = searchQuery.trim();
+  if (!q) return [...events];
+
+  const scored: RankedMatch<T>[] = [];
+  for (const event of events) {
+    const s = scoreEvent(event, q);
+    if (s) scored.push(s);
+  }
+  scored.sort((a, b) => {
+    if (a.tier !== b.tier) return a.tier - b.tier;
+    return b.tiebreaker - a.tiebreaker;
+  });
+  return scored.map((s) => s.event);
+}
+
+/**
+ * Returns true if the event matches the search query (any tier).
+ * Uses the same ranking logic as rankedEventMatchesSearch.
  */
 export function eventMatchesSearch(
   event: SearchableEvent,
   searchQuery: string
 ): boolean {
-  const q = searchQuery.trim();
-  if (!q) return true;
-
-  const searchTerms = getSearchTerms(q);
-  const combined = [event.name, event.description, event.location].join(" ");
-
-  if (searchTerms.length === 0) {
-    return event.name.toLowerCase().includes(q.toLowerCase()) ||
-      event.description.toLowerCase().includes(q.toLowerCase()) ||
-      event.location.toLowerCase().includes(q.toLowerCase());
-  }
-
-  return textMatchesTerms(combined, searchTerms);
+  return rankedEventMatchesSearch([event], searchQuery).length > 0;
 }


### PR DESCRIPTION
<img width="1439" height="648" alt="Screenshot 2026-02-13 at 2 09 03 PM" src="https://github.com/user-attachments/assets/36ee58da-cefb-4b10-bd24-96001391c1eb" />
