### PR TITLE
Fix page scroller wrapping

### DIFF
--- a/app/components/event-list.tsx
+++ b/app/components/event-list.tsx
@@ -102,7 +102,7 @@ export function EventList({
                 <ChevronLeft className="w-4 h-4" />
               </button>
 
-              <span className="text-sm font-medium text-primary">
+              <span className="text-nowrap text-sm font-medium text-primary">
                 {page + 1} / {totalPages}
               </span>
 


### PR DESCRIPTION
### Description of what has been done
Page scroller doesn't wrap like this anymore:

### Screenshots/Videos:
<img width="414" height="48" alt="image" src="https://github.com/user-attachments/assets/06fb588e-d9b0-4331-b436-bcbe5187b2b9" />

### Anything that still doesn't work? 

--

[ ] I have updated the google doc as appropriate

Relevant issue to close or fix (type "Closes #X"): 
