### PR TITLE
relevance sort now sorts by relevance, yellow tags automatically sear…

### DIFF
--- a/app/components/campus-map-inner.tsx
+++ b/app/components/campus-map-inner.tsx
@@ -314,7 +314,7 @@ export default function CampusMapInner({
 
       map.panTo([event.lat, event.lng], {
         animate: true,
-        duration: 0.5,
+        duration: 2.0,
       })
     }, [hoveredEvent, events, map, shouldPan])
 

--- a/app/components/category-filters.tsx
+++ b/app/components/category-filters.tsx
@@ -5,8 +5,8 @@ import { Dog, FlaskConical, Palette, Laugh, Music, Utensils } from "lucide-react
 interface CategoryFiltersProps {
   selectedCategories: string[]
   toggleCategory: (category: string) => void
-  sortOption: "alphabetical" | "time"
-  setSortOption: (option: "alphabetical" | "time") => void
+  sortOption: "relevance" | "alphabetical" | "time"
+  setSortOption: (option: "relevance" | "alphabetical" | "time") => void
 }
 
 const categories = [
@@ -66,7 +66,7 @@ setSortOption,
         <select
           value={sortOption}
           onChange={(e) =>
-            setSortOption(e.target.value as "alphabetical" | "time")
+            setSortOption(e.target.value as "relevance" | "time")
           }
           className="
             w-full
@@ -82,8 +82,9 @@ setSortOption,
             transition
           "
         >
-          <option value="alphabetical">Relevance</option>
+          <option value="relevance">Relevance</option>
           <option value="time">Time</option>
+          <option value="alphabetical">Alphabetical</option>
         </select>
 
       </div>

--- a/app/components/search-section.tsx
+++ b/app/components/search-section.tsx
@@ -175,10 +175,13 @@ export function SearchSection({
 
       {/* Quick Search Tags */}
       <div className="flex flex-wrap gap-2 mt-5 mb-1">
-        {["battle of the bands", "chemistry show", "chick handling", "cockroach racing", "doxie derby", "laser maze", "meet the microbes", "orphan kitten project", "fashion show", "popcorn giveaway", "slime time", "weather balloon"].map((tag) => (
+        {["battle of the bands", "chemistry show", "chick handling", "cockroach racing", "doxie derby", "laser maze"].map((tag) => (
           <button
             key={tag}
-            onClick={() => setSearchQuery(tag)}
+            onClick={() => {
+              setSearchQuery(tag)
+              onSearchSubmit(tag)
+            }}
             className="px-3 py-1 text-xs font-medium bg-accent/20 text-accent-foreground rounded-full hover:bg-accent/30 transition-colors"
           >
             {tag}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,7 +42,7 @@ export default function PicnicDayPage() {
   const [activeTab, setActiveTab] = useState<"browse" | "popular" | "nearby">("browse")
   const [hoveredEvent, setHoveredEvent] = useState<string | null>(null)
   const [shouldPanToHovered, setShouldPanToHovered] = useState(false)
-  const [sortOption, setSortOption] = useState<"alphabetical" | "time">("alphabetical")
+  const [sortOption, setSortOption] = useState<"relevance" | "alphabetical" | "time">("relevance")
 
   const setHoveredEventFromList = useCallback((id: string | null) => {
     setHoveredEvent(id)
@@ -87,7 +87,7 @@ export default function PicnicDayPage() {
 
   const filteredEvents = useMemo(() => {
     let result = searchRanked
-    // Category filtering
+
     if (selectedCategories.length > 0) {
       result = result.filter((event) =>
         selectedCategories.some((category) => {
@@ -102,19 +102,36 @@ export default function PicnicDayPage() {
         })
       )
     }
-    // Sorting
+
+    let sorted = [...result]
+
     if (sortOption === "time") {
-      result = [...result].sort((a, b) =>
-        a.startTime.localeCompare(b.startTime)
-      )
-    } else {
-      // default alphabetical
-      result = [...result].sort((a, b) =>
+      sorted.sort((a, b) => {
+        const startCompare = a.startTime.localeCompare(b.startTime)
+
+        if (startCompare !== 0) return startCompare
+
+        // If start times are equal → earlier end time first
+        return a.endTime.localeCompare(b.endTime)
+      })
+    }
+
+    else if (sortOption === "alphabetical") {
+      sorted.sort((a, b) =>
         a.name.localeCompare(b.name)
       )
     }
-    return result
-  }, [searchRanked, selectedCategories, sortOption])
+
+    else if (sortOption === "relevance") {
+      if (!submittedSearchQuery.trim()) {
+        sorted.sort((a, b) =>
+          a.name.localeCompare(b.name)
+        )
+      }
+    }
+
+    return sorted
+  }, [searchRanked, selectedCategories, sortOption, submittedSearchQuery])
 
   const RESULTS_PAGE_SIZE = 20
   const totalResultsPages = Math.max(1, Math.ceil(filteredEvents.length / RESULTS_PAGE_SIZE))


### PR DESCRIPTION
### Description of what has been done
Closes #
- relevance now sorts by relevance (searching for doxy/doxie derby results in doxbie derby actually being on top lol)
- If events  have same start time, sorts by end time
- made map movement slower (can still be slowed)
- yellow tags search automatcically now. i removed some because there were lowkey too many imo

### Screenshots/Videos:

<img width="1266" height="654" alt="image" src="https://github.com/user-attachments/assets/683adf23-02df-4657-b14c-43ac9eec8563" />
<img width="534" height="234" alt="image" src="https://github.com/user-attachments/assets/af392d85-9c88-426a-8ad4-b90c932f1d3b" />


### Anything that still doesn't work? 

--

[X] I have updated the google doc as appropriate

Relevant issue to close or fix (type "Closes #X"): 
