### PR TITLE
less events displayed at once per page on mobile

### DIFF
--- a/app/components/event-list.tsx
+++ b/app/components/event-list.tsx
@@ -54,13 +54,9 @@ export function EventList({
     onScrollToEventDone()
   }, [scrollToEventId, onScrollToEventDone])
 
-  const pageSize = 20
-  const start = page * pageSize + 1
-  const end = Math.min((page + 1) * pageSize, allFilteredCount)
-
   return (
     <div className="flex-1 lg:flex lg:flex-col lg:min-h-0">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-3">
 
         {/* LEFT — Title */}
         <div className="relative">
@@ -125,7 +121,7 @@ export function EventList({
           )}
         </div>
       </div>
-      <div className="mt-4 lg:flex-1 lg:min-h-0 lg:flex lg:flex-col">
+      <div className="lg:flex-1 lg:min-h-0 lg:flex lg:flex-col">
         <div
           ref={listScrollRef}
           className="space-y-2 lg:flex-1 lg:overflow-y-auto pr-2 -mr-2 lg:mr-0"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -131,7 +131,28 @@ export default function PicnicDayPage() {
     return sorted
   }, [searchRanked, selectedCategories, sortOption, submittedSearchQuery])
 
-  const RESULTS_PAGE_SIZE = 20
+  const [RESULTS_PAGE_SIZE, setResultsPageSize] = useState(20)
+
+  useEffect(() => {
+  const updateSize = () => {
+    const width = window.innerWidth
+
+    if (width < 640) {
+      setResultsPageSize(5)   // phones
+    } 
+    else if (width < 1024) {
+      setResultsPageSize(10)  // tablets / iPad
+    } 
+    else {
+      setResultsPageSize(20)  // desktop
+    }
+  }
+  updateSize()
+  window.addEventListener("resize", updateSize)
+
+  return () => window.removeEventListener("resize", updateSize)
+  }, [])
+
   const totalResultsPages = Math.max(1, Math.ceil(filteredEvents.length / RESULTS_PAGE_SIZE))
   const eventsForCurrentPage = filteredEvents.slice(
     resultsPage * RESULTS_PAGE_SIZE,
@@ -271,7 +292,7 @@ export default function PicnicDayPage() {
                     sortOption={sortOption}
                     setSortOption={setSortOption}
                   />
-                  <div className="flex-1 min-w-0 lg:min-h-0 lg:flex lg:flex-col" data-onboarding="event-list">
+                  <div className="flex-1 min-w-0 lg:min-h-0 lg:flex lg:flex-col -mt-2" data-onboarding="event-list">
                     <EventList
                       events={eventsForCurrentPage}
                       allFilteredCount={filteredEvents.length}


### PR DESCRIPTION
### Description of what has been done
Closes #97 
Only 5 events appear per page on mobile devices, and 10 on tablet devices.

### Screenshots/Videos:

<img width="1138" height="1370" alt="image" src="https://github.com/user-attachments/assets/90ccda1f-53ca-46e7-a49c-e856e24ba8e6" />

### Anything that still doesn't work? 

--

[X] I have updated the google doc as appropriate

Relevant issue to close or fix (type "Closes #X"): 
