### PR TITLE
Fix help button moving outside of search container

### DIFF
--- a/app/components/search-section.tsx
+++ b/app/components/search-section.tsx
@@ -43,13 +43,13 @@ export function SearchSection({
     <div className="bg-card rounded-lg border border-border p-4">
       {/* Search Input + Help */}
       <div className="flex items-center gap-2">
-        <div className="relative flex-1">
+        <div className="relative flex-1 min-w-0">
         <form
           onSubmit={(e) => {
             e.preventDefault()
             onSearchSubmit(searchQuery)
           }}
-          className="flex w-full"
+          className="flex w-full min-w-0"
         >
           {/* Input */}
           <input
@@ -61,6 +61,7 @@ export function SearchSection({
             placeholder="Search for events..."
             className="
               flex-1
+              min-w-0
               px-4
               py-3
               bg-secondary


### PR DESCRIPTION
### Description of what has been done
before the help button would be outside of the white search container. 

### Screenshots/Videos:
<img width="181" height="368" alt="image" src="https://github.com/user-attachments/assets/5f01c936-be4e-4688-9426-b2351798ec57" />

### Anything that still doesn't work? 

--

[ ] I have updated the google doc as appropriate

Relevant issue to close or fix (type "Closes #X"): 
