### PR TITLE
limited the amount of scheduled events shown before scrolling starts

### DIFF
--- a/app/components/campus-map-inner.tsx
+++ b/app/components/campus-map-inner.tsx
@@ -258,30 +258,30 @@ function useOffsetPositions(
 }
 
 function FlyToHoveredEvent({
-    hoveredEvent,
-    events,
-    shouldPan,
-  }: {
-    hoveredEvent: string | null
-    events: (Event | ScheduledEvent)[]
-    shouldPan: boolean
-  }) {
-    const map = useMap()
+  hoveredEvent,
+  events,
+  shouldPan,
+}: {
+  hoveredEvent: string | null
+  events: (Event | ScheduledEvent)[]
+  shouldPan: boolean
+}) {
+  const map = useMap()
 
-    useEffect(() => {
-      if (!shouldPan || !hoveredEvent) return
+  useEffect(() => {
+    if (!shouldPan || !hoveredEvent) return
 
-      const event = events.find((e) => e.id === hoveredEvent)
-      if (!event) return
+    const event = events.find((e) => e.id === hoveredEvent)
+    if (!event) return
 
-      map.panTo([event.lat, event.lng], {
-        animate: true,
-        duration: 2.0,
-      })
-    }, [hoveredEvent, events, map, shouldPan])
+    map.panTo([event.lat, event.lng], {
+      animate: true,
+      duration: 2.0,
+    })
+  }, [hoveredEvent, events, map, shouldPan])
 
-    return null
-  }
+  return null
+}
 
 /* =========================
    Icon Logic
@@ -531,75 +531,60 @@ export default function CampusMapInner({
       data-onboarding="campus-map"
       className="relative w-full min-h-[320px] h-[400px] lg:h-auto lg:flex-1 lg:min-h-0"
     >
-      <div className="absolute bottom-4 left-4 z-[2000]">
-        <div
-          className="rounded-2xl bg-white/95 backdrop-blur px-3.5 py-2.5 shadow-[0_10px_30px_rgba(0,0,0,0.12)] ring-1 ring-black/5 flex flex-col gap-2"
-        >
-          <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-600">
-            Show on map
-          </div>
+      <div className="
+        absolute z-[2000]
+        top-3 right-3
+        lg:top-auto lg:right-auto lg:bottom-3 lg:left-3
+    ">
+        <div className="flex items-center gap-2 bg-white/95 backdrop-blur px-2 py-1.5 rounded-xl shadow-[0_8px_20px_rgba(0,0,0,0.15)] border border-black/5">
 
-          <div className="flex items-center gap-2">
-            {/* Schedule Mode */}
-            <button
-              onClick={() => setShowScheduleOnly((prev) => !prev)}
-              className="flex items-center gap-2 px-3 h-9 rounded-xl text-sm font-semibold transition-all active:scale-95"
+          {/* Scheduled */}
+          <button
+            onClick={() => setShowScheduleOnly((prev) => !prev)}
+            className="flex items-center gap-1.5 px-2.5 h-8 rounded-lg text-xs font-medium transition-all"
+            style={{
+              background: showScheduleOnly ? NAVY : "white",
+              color: showScheduleOnly ? "white" : NAVY,
+              border: `1px solid ${NAVY}`,
+            }}
+          >
+            <span
               style={{
-                background: showScheduleOnly ? NAVY : "white",
-                color: showScheduleOnly ? "white" : NAVY,
-                border: `1.5px solid ${NAVY}`,
-                boxShadow: showScheduleOnly
-                  ? "0 0 0 2px rgba(18,60,115,0.18)"
-                  : "0 2px 8px rgba(0,0,0,0.12)",
+                width: 8,
+                height: 8,
+                borderRadius: "999px",
+                background: GOLD,
               }}
-            >
-              <span
-                className="shrink-0"
-                style={{
-                  width: 12,
-                  height: 12,
-                  borderRadius: "999px",
-                  background: GOLD,
-                  boxShadow: "0 0 0 2px rgba(255,191,0,0.18)",
-                }}
-              />
-              <span className="tracking-tight">Scheduled</span>
-            </button>
+            />
+            <span>Scheduled</span>
+          </button>
 
-            {/* Food Layer */}
-            <button
-              onClick={() => setShowFoodOnly((prev) => !prev)}
-              className="w-9 h-9 rounded-xl flex items-center justify-center transition-all active:scale-95"
-              style={{
-                background: showFoodOnly ? NAVY : "white",
-                color: showFoodOnly ? "white" : NAVY,
-                border: `1.5px solid ${NAVY}`,
-                boxShadow: showFoodOnly
-                  ? "0 0 0 2px rgba(18,60,115,0.18)"
-                  : "0 2px 8px rgba(0,0,0,0.12)",
-                opacity: showFoodOnly ? 1 : 0.9,
-              }}
-            >
-              <LuUtensils size={16} />
-            </button>
+          {/* Food */}
+          <button
+            onClick={() => setShowFoodOnly((prev) => !prev)}
+            className="w-8 h-8 rounded-lg flex items-center justify-center"
+            style={{
+              background: showFoodOnly ? NAVY : "white",
+              color: showFoodOnly ? "white" : NAVY,
+              border: `1px solid ${NAVY}`,
+            }}
+          >
+            <LuUtensils size={14} />
+          </button>
 
-            {/* Restroom Layer */}
-            <button
-              onClick={() => setShowRestroomOnly((prev) => !prev)}
-              className="w-9 h-9 rounded-xl flex items-center justify-center transition-all active:scale-95"
-              style={{
-                background: showRestroomOnly ? NAVY : "white",
-                color: showRestroomOnly ? "white" : NAVY,
-                border: `1.5px solid ${NAVY}`,
-                boxShadow: showRestroomOnly
-                  ? "0 0 0 2px rgba(18,60,115,0.18)"
-                  : "0 2px 8px rgba(0,0,0,0.12)",
-                opacity: showRestroomOnly ? 1 : 0.9,
-              }}
-            >
-              <LuToilet size={16} />
-            </button>
-          </div>
+          {/* Restroom */}
+          <button
+            onClick={() => setShowRestroomOnly((prev) => !prev)}
+            className="w-8 h-8 rounded-lg flex items-center justify-center"
+            style={{
+              background: showRestroomOnly ? NAVY : "white",
+              color: showRestroomOnly ? "white" : NAVY,
+              border: `1px solid ${NAVY}`,
+            }}
+          >
+            <LuToilet size={14} />
+          </button>
+
         </div>
       </div>
       <MapContainer

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -68,7 +68,7 @@ export function MobileScheduleMap(props: any) {
       />
 
       <div
-        className="relative z-0 h-[55vh] rounded-2xl overflow-hidden border"
+        className="relative z-0 h-[55vh] rounded-2xl overflow-hidden border border-border"
         onClick={() => setIsListOpen(false)}
       >
         <CampusMap
@@ -97,14 +97,14 @@ export function MobileScheduleMap(props: any) {
         className={`
           fixed inset-x-0 bottom-0 z-50
           transition-transform duration-300 ease-in-out
-          ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
+          ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-120px)]"}
         `}
       >
         <div
           className="pt-2 pb-2 cursor-pointer"
           onClick={() => setIsListOpen(true)}
         >
-          <div className="bg-white rounded-t-3xl shadow-2xl border-t overflow-hidden">
+          <div className="bg-white rounded-t-3xl shadow-2xl border-t border-border overflow-hidden">
             <div className="px-4 pt-2 pb-2 bg-white/95 backdrop-blur-sm">
 
               {/* HANDLE */}
@@ -115,9 +115,6 @@ export function MobileScheduleMap(props: any) {
                 <div className="w-10 h-1.5 bg-gray-300 rounded-full" />
               </button>
 
-              <div className="text-sm font-medium mb-2 text-center">
-                Browse Events ({nonFoodEvents.length})
-              </div>
 
               <SearchSection
                 events={events}

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -139,7 +139,11 @@ export function MobileScheduleMap(props: any) {
             </div>
 
             {isListOpen && (
+<<<<<<< HEAD
               <div className="max-h-[55vh] overflow-y-auto px-4 pb-4">
+=======
+              <div className="max-h-[70vh] overflow-y-auto px-4 pb-4">
+>>>>>>> 35703f5 (made the card scroll up further)
                 <EventList
                   events={nonFoodEvents.slice(
                     resultsPage * RESULTS_PAGE_SIZE,

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -68,7 +68,7 @@ export function MobileScheduleMap(props: any) {
       />
 
       <div
-        className="relative z-0 h-[55vh] rounded-2xl overflow-hidden border border-border"
+        className="relative z-0 h-[55vh] rounded-2xl overflow-hidden border border-gray-200"
         onClick={() => setIsListOpen(false)}
       >
         <CampusMap
@@ -97,14 +97,14 @@ export function MobileScheduleMap(props: any) {
         className={`
           fixed inset-x-0 bottom-0 z-50
           transition-transform duration-300 ease-in-out
-          ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-120px)]"}
+          ${isListOpen ? "translate-y-[140px]" : "translate-y-[calc(100%-140px)]"}
         `}
       >
         <div
           className="pt-2 pb-2 cursor-pointer"
           onClick={() => setIsListOpen(true)}
         >
-          <div className="bg-white rounded-t-3xl shadow-2xl border-t border-border overflow-hidden">
+          <div className="bg-white rounded-t-3xl shadow-2xl overflow-hidden">
             <div className="px-4 pt-2 pb-2 bg-white/95 backdrop-blur-sm">
 
               {/* HANDLE */}
@@ -115,6 +115,9 @@ export function MobileScheduleMap(props: any) {
                 <div className="w-10 h-1.5 bg-gray-300 rounded-full" />
               </button>
 
+              <div className="text-sm font-medium mb-2 text-center">
+                Browse Events ({nonFoodEvents.length})
+              </div>
 
               <SearchSection
                 events={events}
@@ -136,11 +139,7 @@ export function MobileScheduleMap(props: any) {
             </div>
 
             {isListOpen && (
-<<<<<<< HEAD
-              <div className="max-h-[55vh] overflow-y-auto px-4 pb-4">
-=======
               <div className="max-h-[70vh] overflow-y-auto px-4 pb-4">
->>>>>>> 35703f5 (made the card scroll up further)
                 <EventList
                   events={nonFoodEvents.slice(
                     resultsPage * RESULTS_PAGE_SIZE,

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -5,7 +5,6 @@ import { SchedulePanel } from "@/app/components/schedule-panel"
 import { EventList } from "@/app/components/event-list"
 import { SearchSection } from "@/app/components/search-section"
 import { useEffect, useState } from "react"
-import { ChevronUp } from "lucide-react"
 
 export function MobileScheduleMap(props: any) {
   const {
@@ -58,7 +57,7 @@ export function MobileScheduleMap(props: any) {
   }, [searchQuery])
 
   return (
-    <div className="flex flex-col gap-4 px-4 py-3 pb-24">
+    <div className="flex flex-col gap-4 py-3 pb-24">
       <SchedulePanel
         scheduledEvents={scheduledEvents}
         removeFromSchedule={removeFromSchedule}
@@ -89,23 +88,23 @@ export function MobileScheduleMap(props: any) {
 
       {isListOpen && (
         <div
-          className="fixed inset-0 bg-black/10 z-40"
+           className="fixed inset-0 bg-black/25 z-40 transition-opacity"
           onClick={() => setIsListOpen(false)}
         />
       )}
 
       <div
         className={`
-          fixed left-0 right-0 bottom-0 z-50
+          fixed inset-x-0 bottom-0 z-50
           transition-transform duration-300 ease-in-out
           ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
         `}
       >
         <div
-          className="px-4 pt-2 pb-2 cursor-pointer"
+          className="pt-2 pb-2 cursor-pointer"
           onClick={() => setIsListOpen(true)}
         >
-          <div className="bg-white rounded-t-2xl shadow-xl border-t">
+          <div className="bg-white rounded-t-3xl shadow-2xl border-t overflow-hidden">
             <div className="px-4 pt-2 pb-2 bg-white/95 backdrop-blur-sm">
 
               {/* HANDLE */}

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -5,6 +5,7 @@ import { SchedulePanel } from "@/app/components/schedule-panel"
 import { EventList } from "@/app/components/event-list"
 import { SearchSection } from "@/app/components/search-section"
 import { useEffect, useState } from "react"
+import { ChevronUp } from "lucide-react"
 
 export function MobileScheduleMap(props: any) {
   const {
@@ -57,7 +58,7 @@ export function MobileScheduleMap(props: any) {
   }, [searchQuery])
 
   return (
-    <div className="flex flex-col gap-4 py-3 pb-24">
+    <div className="flex flex-col gap-4 px-4 py-3 pb-24">
       <SchedulePanel
         scheduledEvents={scheduledEvents}
         removeFromSchedule={removeFromSchedule}
@@ -88,23 +89,23 @@ export function MobileScheduleMap(props: any) {
 
       {isListOpen && (
         <div
-           className="fixed inset-0 bg-black/25 z-40 transition-opacity"
+          className="fixed inset-0 bg-black/10 z-40"
           onClick={() => setIsListOpen(false)}
         />
       )}
 
       <div
         className={`
-          fixed inset-x-0 bottom-0 z-50
+          fixed left-0 right-0 bottom-0 z-50
           transition-transform duration-300 ease-in-out
           ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
         `}
       >
         <div
-          className="pt-2 pb-2 cursor-pointer"
+          className="px-4 pt-2 pb-2 cursor-pointer"
           onClick={() => setIsListOpen(true)}
         >
-          <div className="bg-white rounded-t-3xl shadow-2xl border-t overflow-hidden">
+          <div className="bg-white rounded-t-2xl shadow-xl border-t">
             <div className="px-4 pt-2 pb-2 bg-white/95 backdrop-blur-sm">
 
               {/* HANDLE */}

--- a/app/components/schedule-panel.tsx
+++ b/app/components/schedule-panel.tsx
@@ -102,7 +102,7 @@ export function SchedulePanel({
               </p>
             </div>
           ) : (
-            <div className="p-2 max-h-[70vh] overflow-y-auto lg:max-h-[300px]">
+            <div className="p-2 max-h-[185px] overflow-y-auto lg:max-h-[300px]">
               {scheduledEvents.map((event, index) => {
                 const outOfOrder = isOutOfOrder(scheduledEvents, index)
                 const isDragging = draggedIndex === index

--- a/app/components/schedule-panel.tsx
+++ b/app/components/schedule-panel.tsx
@@ -72,7 +72,7 @@ export function SchedulePanel({
   return (
     <div
       data-onboarding="schedule-panel"
-      className={`w-full bg-card border border-border rounded-lg shadow-lg transition-all lg:absolute lg:left-auto lg:right-4 lg:top-4 lg:bottom-auto lg:w-72 lg:z-[1000] ${isCollapsed ? "h-auto" : "lg:max-h-[440px]"
+      className={`w-full bg-card border border-border rounded-lg shadow-lg transition-all lg:absolute lg:left-auto lg:right-4 lg:top-4 lg:bottom-auto lg:w-72 lg:z-[1000] ${isCollapsed ? "h-auto" : "h-[300px] lg:max-h-[440px]"
         }`}
     >
       {/* Header */}
@@ -102,7 +102,7 @@ export function SchedulePanel({
               </p>
             </div>
           ) : (
-            <div className="p-2 max-h-[185px] overflow-y-auto lg:max-h-[300px]">
+            <div className="p-2 h-[200px] overflow-y-auto lg:max-h-[300px]">
               {scheduledEvents.map((event, index) => {
                 const outOfOrder = isOutOfOrder(scheduledEvents, index)
                 const isDragging = draggedIndex === index
@@ -115,8 +115,8 @@ export function SchedulePanel({
                     onDragOver={(e) => handleDragOver(e, index)}
                     onDragEnd={handleDragEnd}
                     className={`relative flex items-start gap-2 p-2 rounded-lg mb-1 transition-all ${isDragging
-                        ? "opacity-50 bg-muted"
-                        : "bg-secondary/50 hover:bg-secondary"
+                      ? "opacity-50 bg-muted"
+                      : "bg-secondary/50 hover:bg-secondary"
                       }`}
                   >
                     {/* Drag Handle */}
@@ -130,50 +130,48 @@ export function SchedulePanel({
                     </div>
 
                     {/* Event Info */}
-                      <div
-                        className="flex-1 min-w-0 cursor-pointer"
-                        onClick={() =>
-                          setExpandedId(expandedId === event.id ? null : event.id)
-                        }
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <p
-                            className={`text-sm font-medium text-foreground ${
-                              expandedId === event.id ? "" : "line-clamp-2"
+                    <div
+                      className="flex-1 min-w-0 cursor-pointer"
+                      onClick={() =>
+                        setExpandedId(expandedId === event.id ? null : event.id)
+                      }
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <p
+                          className={`text-sm font-medium text-foreground ${expandedId === event.id ? "" : "line-clamp-2"
                             }`}
-                          >
-                            {event.name}
-                          </p>
-                          <ChevronDown
-                            className={`w-5 h-5 mt-0.5 text-muted-foreground transition-transform flex-shrink-0 ${
-                              expandedId === event.id ? "rotate-180" : ""
-                            }`}
-                          />
-                        </div>
-
-
-                        <p className="text-[10px] text-muted-foreground">
-                          {(event.startTime)} · {event.location}
-                          {event.location_details && (
-                            <> — {event.location_details}</>
-                          )}
+                        >
+                          {event.name}
                         </p>
-
-                        {expandedId === event.id && event.description && (
-                          <p className="mt-1 text-xs text-muted-foreground leading-snug">
-                            {event.description}
-                          </p>
-                        )}
-
-                        {outOfOrder && (
-                          <div className="flex items-center gap-1 mt-1 text-destructive">
-                            <AlertTriangle className="w-3 h-3" />
-                            <span className="text-[10px] font-medium">
-                              Time conflict with previous event
-                            </span>
-                          </div>
-                        )}
+                        <ChevronDown
+                          className={`w-5 h-5 mt-0.5 text-muted-foreground transition-transform flex-shrink-0 ${expandedId === event.id ? "rotate-180" : ""
+                            }`}
+                        />
                       </div>
+
+
+                      <p className="text-[10px] text-muted-foreground">
+                        {(event.startTime)} · {event.location}
+                        {event.location_details && (
+                          <> — {event.location_details}</>
+                        )}
+                      </p>
+
+                      {expandedId === event.id && event.description && (
+                        <p className="mt-1 text-xs text-muted-foreground leading-snug">
+                          {event.description}
+                        </p>
+                      )}
+
+                      {outOfOrder && (
+                        <div className="flex items-center gap-1 mt-1 text-destructive">
+                          <AlertTriangle className="w-3 h-3" />
+                          <span className="text-[10px] font-medium">
+                            Time conflict with previous event
+                          </span>
+                        </div>
+                      )}
+                    </div>
 
 
                     {/* Actions 
@@ -202,7 +200,7 @@ export function SchedulePanel({
                       <X className="w-3 h-3" />
                     </button>
                   </div>
-                  
+
                 )
               })}
             </div>

--- a/app/components/search-section.tsx
+++ b/app/components/search-section.tsx
@@ -131,20 +131,20 @@ export function SearchSection({
               aria-controls="search-suggestions"
               aria-autocomplete="list"
               className="
-              flex-1
-              min-w-0
-              px-4
-              py-3
-              bg-secondary
-              border border-border
-              rounded-l-lg
-              text-foreground
-              placeholder:text-muted-foreground
-              focus:outline-none
-              focus:ring-2
-              focus:ring-primary/25
-              focus:border-primary
-              transition-all
+                flex-1
+                min-w-0
+                px-4
+                py-3
+                bg-secondary
+                border border-primary/20
+                rounded-l-lg
+                text-foreground
+                placeholder:text-muted-foreground
+                focus:outline-none
+                focus:ring-2
+                focus:ring-primary/25
+                focus:border-primary
+                transition-all
             "
             />
 
@@ -161,7 +161,7 @@ export function SearchSection({
             <div
               id="search-suggestions"
               role="listbox"
-              className="absolute z-30 mt-2 w-full bg-card border border-border rounded-lg shadow-[0_10px_25px_rgba(2,40,81,0.08)] max-h-72 overflow-y-auto"
+              className="absolute z-[70] mt-2 w-full bg-card border border-border rounded-lg shadow-[0_10px_25px_rgba(2,40,81,0.08)] max-h-72 overflow-y-auto"
             >
               {showNoResults ? (
                 <div className="px-4 py-3 text-sm text-muted-foreground">
@@ -266,7 +266,6 @@ export function SearchSection({
           <HelpCircle className="h-5 w-5" strokeWidth={2} />
         </button>
       </div>
-<<<<<<< HEAD
 
       {activeFeedTab === "recommended" && (
         <div className="mt-5 rounded-xl bg-[#FEF9E7] px-4 py-3.5 ring-1 ring-[#F3E5AB]/80">
@@ -319,12 +318,6 @@ export function SearchSection({
           FILTER BY
         </h3>
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-=======
-      {/* {/* Quick Search Tags 
-      <div className="flex flex-wrap gap-2 mt-3">
-        <div className="px-1 py-1 text-(--color-muted-foreground) text-xs italic ">Suggested Searches</div>
-        {["battle of the bands", "chemistry show", "chick handling", "cockroach racing", "doxie derby", "laser maze"].map((tag) => (
->>>>>>> f10c7ce (fixed UI of the new search card)
           <button
             type="button"
             onClick={onSelectRecommended}

--- a/app/components/search-section.tsx
+++ b/app/components/search-section.tsx
@@ -131,20 +131,20 @@ export function SearchSection({
               aria-controls="search-suggestions"
               aria-autocomplete="list"
               className="
-                flex-1
-                min-w-0
-                px-4
-                py-3
-                bg-secondary
-                border border-primary/20
-                rounded-l-lg
-                text-foreground
-                placeholder:text-muted-foreground
-                focus:outline-none
-                focus:ring-2
-                focus:ring-primary/25
-                focus:border-primary
-                transition-all
+              flex-1
+              min-w-0
+              px-4
+              py-3
+              bg-secondary
+              border border-border
+              rounded-l-lg
+              text-foreground
+              placeholder:text-muted-foreground
+              focus:outline-none
+              focus:ring-2
+              focus:ring-primary/25
+              focus:border-primary
+              transition-all
             "
             />
 
@@ -161,7 +161,7 @@ export function SearchSection({
             <div
               id="search-suggestions"
               role="listbox"
-              className="absolute z-[70] mt-2 w-full bg-card border border-border rounded-lg shadow-[0_10px_25px_rgba(2,40,81,0.08)] max-h-72 overflow-y-auto"
+              className="absolute z-30 mt-2 w-full bg-card border border-border rounded-lg shadow-[0_10px_25px_rgba(2,40,81,0.08)] max-h-72 overflow-y-auto"
             >
               {showNoResults ? (
                 <div className="px-4 py-3 text-sm text-muted-foreground">

--- a/app/components/search-section.tsx
+++ b/app/components/search-section.tsx
@@ -266,6 +266,7 @@ export function SearchSection({
           <HelpCircle className="h-5 w-5" strokeWidth={2} />
         </button>
       </div>
+<<<<<<< HEAD
 
       {activeFeedTab === "recommended" && (
         <div className="mt-5 rounded-xl bg-[#FEF9E7] px-4 py-3.5 ring-1 ring-[#F3E5AB]/80">
@@ -318,6 +319,12 @@ export function SearchSection({
           FILTER BY
         </h3>
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+=======
+      {/* {/* Quick Search Tags 
+      <div className="flex flex-wrap gap-2 mt-3">
+        <div className="px-1 py-1 text-(--color-muted-foreground) text-xs italic ">Suggested Searches</div>
+        {["battle of the bands", "chemistry show", "chick handling", "cockroach racing", "doxie derby", "laser maze"].map((tag) => (
+>>>>>>> f10c7ce (fixed UI of the new search card)
           <button
             type="button"
             onClick={onSelectRecommended}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,8 +3,6 @@
 import { useState, useCallback, useEffect, useMemo } from "react"
 
 // components
-
-// components
 import { SearchSection } from "@/app/components/search-section"
 import { EventList } from "@/app/components/event-list"
 import { CampusMap } from "@/app/components/campus-map"


### PR DESCRIPTION
### Description of what has been done
- Scheduled events take up an appropriate amount of space, any overflow will scroll
- removed black outline around map and card that slides up
- moved the map filters to the top right (on desktop they are on the lower left corner)

### Screenshots/Videos:
<img width="746" height="1464" alt="image" src="https://github.com/user-attachments/assets/ca90bb9a-039e-4472-9d76-20d986da581e" />


### Anything that still doesn't work? 

--

[ ] I have updated the google doc as appropriate

Relevant issue to close or fix (type "Closes #X"): 
