### PR TITLE
Jordan/mobile reorder

### DIFF
--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -88,29 +88,13 @@ export function MobileScheduleMap(props: any) {
 
       {isListOpen && (
         <div
-<<<<<<< HEAD
-          className="fixed inset-0 bg-black/40 z-40"
-=======
            className="fixed inset-0 bg-black/25 z-40 transition-opacity"
->>>>>>> f10c7ce (fixed UI of the new search card)
           onClick={() => setIsListOpen(false)}
         />
       )}
 
       <div
         className={`
-<<<<<<< HEAD
-    fixed left-0 right-0 bottom-0 z-50
-    transition-transform duration-300 ease-in-out
-    ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
-  `}
-      >
-        <div
-          onClick={() => setIsListOpen(true)}
-        >
-          <div className="bg-white rounded-t-2xl shadow-xl border-t overflow-hidden">
-            <div className="pt-2 pb-2 bg-white">
-=======
           fixed inset-x-0 bottom-0 z-50
           transition-transform duration-300 ease-in-out
           ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
@@ -124,7 +108,6 @@ export function MobileScheduleMap(props: any) {
             <div className="px-4 pt-2 pb-2 bg-white/95 backdrop-blur-sm">
 
               {/* HANDLE */}
->>>>>>> f10c7ce (fixed UI of the new search card)
               <button
                 onClick={() => setIsListOpen(prev => !prev)}
                 className="w-full flex flex-col items-center mb-2"

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -57,7 +57,7 @@ export function MobileScheduleMap(props: any) {
   }, [searchQuery])
 
   return (
-    <div className="flex flex-col gap-4 px-4 py-3 pb-24">
+    <div className="flex flex-col gap-4 py-3 pb-24">
       <SchedulePanel
         scheduledEvents={scheduledEvents}
         removeFromSchedule={removeFromSchedule}
@@ -88,13 +88,18 @@ export function MobileScheduleMap(props: any) {
 
       {isListOpen && (
         <div
+<<<<<<< HEAD
           className="fixed inset-0 bg-black/40 z-40"
+=======
+           className="fixed inset-0 bg-black/25 z-40 transition-opacity"
+>>>>>>> f10c7ce (fixed UI of the new search card)
           onClick={() => setIsListOpen(false)}
         />
       )}
 
       <div
         className={`
+<<<<<<< HEAD
     fixed left-0 right-0 bottom-0 z-50
     transition-transform duration-300 ease-in-out
     ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
@@ -105,6 +110,21 @@ export function MobileScheduleMap(props: any) {
         >
           <div className="bg-white rounded-t-2xl shadow-xl border-t overflow-hidden">
             <div className="pt-2 pb-2 bg-white">
+=======
+          fixed inset-x-0 bottom-0 z-50
+          transition-transform duration-300 ease-in-out
+          ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
+        `}
+      >
+        <div
+          className="pt-2 pb-2 cursor-pointer"
+          onClick={() => setIsListOpen(true)}
+        >
+          <div className="bg-white rounded-t-3xl shadow-2xl border-t overflow-hidden">
+            <div className="px-4 pt-2 pb-2 bg-white/95 backdrop-blur-sm">
+
+              {/* HANDLE */}
+>>>>>>> f10c7ce (fixed UI of the new search card)
               <button
                 onClick={() => setIsListOpen(prev => !prev)}
                 className="w-full flex flex-col items-center mb-2"

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -49,6 +49,7 @@ export function MobileScheduleMap(props: any) {
   } = props
 
   const [isListOpen, setIsListOpen] = useState(false)
+
   useEffect(() => {
     if (searchQuery.trim().length > 0) {
       setIsListOpen(true)
@@ -66,7 +67,6 @@ export function MobileScheduleMap(props: any) {
         isExporting={isExportingPdf}
       />
 
-      {/* Map */}
       <div
         className="relative z-0 h-[55vh] rounded-2xl overflow-hidden border"
         onClick={() => setIsListOpen(false)}
@@ -86,30 +86,25 @@ export function MobileScheduleMap(props: any) {
         />
       </div>
 
-      {/* Overlay */}
       {isListOpen && (
         <div
-          className="fixed inset-0 bg-black/10 z-40"
+          className="fixed inset-0 bg-black/40 z-40"
           onClick={() => setIsListOpen(false)}
         />
       )}
 
-
       <div
         className={`
-          fixed left-0 right-0 bottom-0 z-50
-          transition-transform duration-300 ease-in-out
-          ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
-        `}
+    fixed left-0 right-0 bottom-0 z-50
+    transition-transform duration-300 ease-in-out
+    ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
+  `}
       >
         <div
-          className="px-4 pt-2 pb-2 cursor-pointer"
           onClick={() => setIsListOpen(true)}
         >
-          <div className="bg-white rounded-t-2xl shadow-xl border-t">
-            <div className="px-4 pt-2 pb-2 bg-white/95 backdrop-blur-sm">
-
-              {/* HANDLE */}
+          <div className="bg-white rounded-t-2xl shadow-xl border-t overflow-hidden">
+            <div className="pt-2 pb-2 bg-white">
               <button
                 onClick={() => setIsListOpen(prev => !prev)}
                 className="w-full flex flex-col items-center mb-2"
@@ -121,7 +116,6 @@ export function MobileScheduleMap(props: any) {
                 Browse Events ({nonFoodEvents.length})
               </div>
 
-              {/* SEARCH (always visible!) */}
               <SearchSection
                 events={events}
                 searchHistory={searchHistory}
@@ -141,9 +135,8 @@ export function MobileScheduleMap(props: any) {
               />
             </div>
 
-            {/* EXPANDABLE CONTENT */}
             {isListOpen && (
-              <div className="max-h-[60vh] overflow-y-auto px-4 pb-4">
+              <div className="max-h-[55vh] overflow-y-auto px-4 pb-4">
                 <EventList
                   events={nonFoodEvents.slice(
                     resultsPage * RESULTS_PAGE_SIZE,
@@ -167,7 +160,6 @@ export function MobileScheduleMap(props: any) {
                 />
               </div>
             )}
-
           </div>
         </div>
       </div>

--- a/app/components/search-section.tsx
+++ b/app/components/search-section.tsx
@@ -131,15 +131,6 @@ export function SearchSection({
               aria-controls="search-suggestions"
               aria-autocomplete="list"
               className="
-<<<<<<< HEAD
-                h-12 min-w-0 flex-1
-                rounded-l-xl border border-[#B8D4E8] bg-[#E6F0F9]
-                px-4 text-sm text-[#002D62]
-                placeholder:text-[#64748B]
-                transition-all
-                focus:border-[#002D62] focus:outline-none focus:ring-2 focus:ring-[#002D62]/20
-              "
-=======
                 flex-1
                 min-w-0
                 px-4
@@ -155,7 +146,6 @@ export function SearchSection({
                 focus:border-primary
                 transition-all
             "
->>>>>>> f10c7ce (fixed UI of the new search card)
             />
 
             <button
@@ -171,11 +161,7 @@ export function SearchSection({
             <div
               id="search-suggestions"
               role="listbox"
-<<<<<<< HEAD
-              className="absolute z-30 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-border bg-card shadow-[0_10px_25px_rgba(2,40,81,0.08)]"
-=======
               className="absolute z-[70] mt-2 w-full bg-card border border-border rounded-lg shadow-[0_10px_25px_rgba(2,40,81,0.08)] max-h-72 overflow-y-auto"
->>>>>>> f10c7ce (fixed UI of the new search card)
             >
               {showNoResults ? (
                 <div className="px-4 py-3 text-sm text-muted-foreground">
@@ -280,7 +266,6 @@ export function SearchSection({
           <HelpCircle className="h-5 w-5" strokeWidth={2} />
         </button>
       </div>
-<<<<<<< HEAD
 
       {activeFeedTab === "recommended" && (
         <div className="mt-5 rounded-xl bg-[#FEF9E7] px-4 py-3.5 ring-1 ring-[#F3E5AB]/80">
@@ -333,12 +318,6 @@ export function SearchSection({
           FILTER BY
         </h3>
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-=======
-      {/* {/* Quick Search Tags 
-      <div className="flex flex-wrap gap-2 mt-3">
-        <div className="px-1 py-1 text-(--color-muted-foreground) text-xs italic ">Suggested Searches</div>
-        {["battle of the bands", "chemistry show", "chick handling", "cockroach racing", "doxie derby", "laser maze"].map((tag) => (
->>>>>>> f10c7ce (fixed UI of the new search card)
           <button
             type="button"
             onClick={onSelectRecommended}

--- a/app/components/search-section.tsx
+++ b/app/components/search-section.tsx
@@ -131,6 +131,7 @@ export function SearchSection({
               aria-controls="search-suggestions"
               aria-autocomplete="list"
               className="
+<<<<<<< HEAD
                 h-12 min-w-0 flex-1
                 rounded-l-xl border border-[#B8D4E8] bg-[#E6F0F9]
                 px-4 text-sm text-[#002D62]
@@ -138,6 +139,23 @@ export function SearchSection({
                 transition-all
                 focus:border-[#002D62] focus:outline-none focus:ring-2 focus:ring-[#002D62]/20
               "
+=======
+                flex-1
+                min-w-0
+                px-4
+                py-3
+                bg-secondary
+                border border-primary/20
+                rounded-l-lg
+                text-foreground
+                placeholder:text-muted-foreground
+                focus:outline-none
+                focus:ring-2
+                focus:ring-primary/25
+                focus:border-primary
+                transition-all
+            "
+>>>>>>> f10c7ce (fixed UI of the new search card)
             />
 
             <button
@@ -153,7 +171,11 @@ export function SearchSection({
             <div
               id="search-suggestions"
               role="listbox"
+<<<<<<< HEAD
               className="absolute z-30 mt-2 max-h-72 w-full overflow-y-auto rounded-lg border border-border bg-card shadow-[0_10px_25px_rgba(2,40,81,0.08)]"
+=======
+              className="absolute z-[70] mt-2 w-full bg-card border border-border rounded-lg shadow-[0_10px_25px_rgba(2,40,81,0.08)] max-h-72 overflow-y-auto"
+>>>>>>> f10c7ce (fixed UI of the new search card)
             >
               {showNoResults ? (
                 <div className="px-4 py-3 text-sm text-muted-foreground">
@@ -258,6 +280,7 @@ export function SearchSection({
           <HelpCircle className="h-5 w-5" strokeWidth={2} />
         </button>
       </div>
+<<<<<<< HEAD
 
       {activeFeedTab === "recommended" && (
         <div className="mt-5 rounded-xl bg-[#FEF9E7] px-4 py-3.5 ring-1 ring-[#F3E5AB]/80">
@@ -310,6 +333,12 @@ export function SearchSection({
           FILTER BY
         </h3>
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+=======
+      {/* {/* Quick Search Tags 
+      <div className="flex flex-wrap gap-2 mt-3">
+        <div className="px-1 py-1 text-(--color-muted-foreground) text-xs italic ">Suggested Searches</div>
+        {["battle of the bands", "chemistry show", "chick handling", "cockroach racing", "doxie derby", "laser maze"].map((tag) => (
+>>>>>>> f10c7ce (fixed UI of the new search card)
           <button
             type="button"
             onClick={onSelectRecommended}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useCallback, useEffect, useMemo } from "react"
 
 // components
+
+// components
 import { SearchSection } from "@/app/components/search-section"
 import { EventList } from "@/app/components/event-list"
 import { CampusMap } from "@/app/components/campus-map"
@@ -228,7 +230,6 @@ export default function PicnicDayPage() {
     return () => window.removeEventListener("resize", updateSize)
   }, [])
 
-  // derived data
 
   const searchRanked = useMemo(() => {
     if (submittedSearchQuery.trim()) {
@@ -323,6 +324,10 @@ export default function PicnicDayPage() {
     setScheduledEvents(prev => prev.filter(e => e.id !== eventId))
   }, [])
 
+  const clearSearchHistory = () => {
+    setSearchHistory([])
+  }
+
   const reorderSchedule = useCallback((from: number, to: number) => {
     setScheduledEvents(prev => {
       const result = [...prev]
@@ -358,10 +363,6 @@ export default function PicnicDayPage() {
     setSelectedCategories([])
     setResultsPage(0)
   }, [])
-
-  const clearSearchHistory = () => {
-    setSearchHistory([])
-  }
 
   const handleExportPdf = async () => {
     setIsExportingPdf(true)
@@ -502,21 +503,21 @@ export default function PicnicDayPage() {
                       }
 
                       setActiveFeedTab("all")
-                      setSearchQuery(finalQuery)
-                      setSubmittedSearchQuery(finalQuery)
-                      setResultsPage(0)
+                    setSearchQuery(finalQuery)
+                    setSubmittedSearchQuery(finalQuery)
+                    setResultsPage(0)
 
-                      setSearchHistory(prev => {
-                        const updated = [
-                          finalQuery,
-                          ...prev.filter(q => q !== finalQuery)
-                        ]
-                        return updated.slice(0, 5)
-                      })
-                    }}
-                    clearSearchHistory={clearSearchHistory}
-                  />
-                </div>
+                    setSearchHistory(prev => {
+                      const updated = [
+                        finalQuery,
+                        ...prev.filter(q => q !== finalQuery)
+                      ]
+                      return updated.slice(0, 5)
+                    })
+                  }}
+                  clearSearchHistory={clearSearchHistory}
+                />
+              </div>
 
                 <div data-onboarding="event-list" className="mt-6 flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden lg:min-h-0">
                   <EventList


### PR DESCRIPTION
### Description of what has been done
- merged Himani's personalization feature onto mobile version 
- reordered every component to fit onto mobile view according to the figma
- event browsing card slides up

### Screenshots/Videos:
<img width="1030" height="1494" alt="image" src="https://github.com/user-attachments/assets/61360eb2-49f6-4923-b4f0-de9ea47e6783" />
<img width="1016" height="1474" alt="image" src="https://github.com/user-attachments/assets/f1602d38-0253-462a-aaf1-f8d1bf933457" />


### Anything that still doesn't work? 

--

[ ] I have updated the google doc as appropriate

Relevant issue to close or fix (type "Closes #X"): 
