### PR TITLE
many mobile optimizations w/ onboarding fixes for mobile.

### DIFF
--- a/app/components/campus-map-inner.tsx
+++ b/app/components/campus-map-inner.tsx
@@ -149,6 +149,32 @@ function FitBoundsOnExport({
 }) {
   const map = useMap();
 
+  // Freeze all interactions while exporting so a stray touch can't pan the map
+  // during html2canvas capture.
+  useEffect(() => {
+    if (!isExporting) return;
+    map.dragging.disable();
+    map.touchZoom.disable();
+    map.scrollWheelZoom.disable();
+    map.doubleClickZoom.disable();
+    map.boxZoom.disable();
+    map.keyboard.disable();
+    if ((map as unknown as { tap?: { disable(): void; enable(): void } }).tap) {
+      (map as unknown as { tap: { disable(): void; enable(): void } }).tap.disable();
+    }
+    return () => {
+      map.dragging.enable();
+      map.touchZoom.enable();
+      map.scrollWheelZoom.enable();
+      map.doubleClickZoom.enable();
+      map.boxZoom.enable();
+      map.keyboard.enable();
+      if ((map as unknown as { tap?: { disable(): void; enable(): void } }).tap) {
+        (map as unknown as { tap: { disable(): void; enable(): void } }).tap.enable();
+      }
+    };
+  }, [isExporting, map]);
+
   useEffect(() => {
     if (!isExporting || points.length === 0) return;
 
@@ -529,7 +555,7 @@ export default function CampusMapInner({
   return (
     <div
       data-onboarding="campus-map"
-      className="relative w-full min-h-[320px] h-[400px] lg:h-auto lg:flex-1 lg:min-h-0"
+      className="relative w-full h-full lg:h-auto lg:flex-1 lg:min-h-0"
     >
       <div className="
         absolute z-[2000]

--- a/app/components/mobile/mobile-view.tsx
+++ b/app/components/mobile/mobile-view.tsx
@@ -50,6 +50,7 @@ export function MobileScheduleMap(props: any) {
   } = props
 
   const [isListOpen, setIsListOpen] = useState(false)
+  const { tutorialStep } = useOnboarding()
 
   useEffect(() => {
     if (searchQuery.trim().length > 0) {
@@ -57,17 +58,21 @@ export function MobileScheduleMap(props: any) {
     }
   }, [searchQuery])
 
+  useEffect(() => {
+    if (tutorialStep === 2) {
+      setIsListOpen(false)
+    } else if (tutorialStep === 0 || tutorialStep === 1) {
+      setIsListOpen(true)
+    }
+  }, [tutorialStep])
+
   const paginatedEvents = nonFoodEvents.slice(
     resultsPage * RESULTS_PAGE_SIZE,
     (resultsPage + 1) * RESULTS_PAGE_SIZE
   )
 
-  useEffect(() => {
-    setIsListOpen(true)
-  }, [])
-
   return (
-    <div className="flex flex-col gap-4 bg-background py-3 pb-24">
+    <div className="flex h-[100dvh] flex-col gap-4 bg-background py-3 pb-[120px]">
       <div data-onboarding="schedule-panel">
         <SchedulePanel
           scheduledEvents={scheduledEvents}
@@ -80,8 +85,8 @@ export function MobileScheduleMap(props: any) {
       </div>
 
       <div
-        data-onboarding="map"
-        className="relative z-0 h-[55vh] overflow-hidden rounded-2xl border border-gray-200"
+        data-onboarding="campus-map"
+        className="relative z-0 min-h-0 flex-1 overflow-hidden rounded-2xl border border-gray-200"
         onClick={() => setIsListOpen(false)}
       >
         <CampusMap
@@ -110,14 +115,14 @@ export function MobileScheduleMap(props: any) {
         className={`
           fixed inset-x-0 bottom-0 z-50
           transition-transform duration-300 ease-in-out
-          ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-140px)]"}
+          ${isListOpen ? "translate-y-0" : "translate-y-[calc(100%-120px)]"}
         `}
       >
         <div onClick={() => setIsListOpen(true)}>
           <div
             className={`
               flex flex-col rounded-t-3xl bg-white shadow-2xl
-              ${isListOpen ? "h-[85dvh]" : "h-[140px]"}
+              ${isListOpen ? "h-[85dvh]" : "h-[120px]"}
             `}
           >
             <div

--- a/app/components/onboarding/onboarding-provider.tsx
+++ b/app/components/onboarding/onboarding-provider.tsx
@@ -14,12 +14,14 @@ interface OnboardingContextValue {
   restart: () => void
   openPersonalizationEditor: () => void
   closePersonalizationEditor: () => void
+  tutorialStep: number | null
 }
 
 const OnboardingContext = createContext<OnboardingContextValue>({
   restart: () => {},
   openPersonalizationEditor: () => {},
   closePersonalizationEditor: () => {},
+  tutorialStep: null,
 })
 
 export function useOnboarding() {
@@ -91,6 +93,7 @@ export function OnboardingProvider({
 
   const handleNext = useCallback(() => {
     if (step >= TUTORIAL_STEPS.length - 1) {
+      onClearScheduleRef.current?.()
       setPhase("personalization")
     } else {
       setStep(step + 1)
@@ -126,6 +129,7 @@ export function OnboardingProvider({
         restart,
         openPersonalizationEditor,
         closePersonalizationEditor,
+        tutorialStep: phase === "tutorial" ? step : null,
       }}
     >
       {children}

--- a/app/components/onboarding/spotlight-overlay.tsx
+++ b/app/components/onboarding/spotlight-overlay.tsx
@@ -21,6 +21,7 @@ interface SpotlightOverlayProps {
 export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: SpotlightOverlayProps) {
   const [rect, setRect] = useState<DOMRect | null>(null)
   const [rectTarget, setRectTarget] = useState<string | null>(null)
+  const [targetRadius, setTargetRadius] = useState<number>(12)
   const [isMobile, setIsMobile] = useState(false)
   const current: TutorialStep = TUTORIAL_STEPS[step]
   const isLast = step === TUTORIAL_STEPS.length - 1
@@ -43,8 +44,11 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
     if (!hasScrolledRef.current) return
     const el = document.querySelector(`[data-onboarding="${current.target}"]`)
     if (el) {
-      setRect(el.getBoundingClientRect())
+      setRect(measureUnionRect(el))
       setRectTarget(current.target)
+      const cs = window.getComputedStyle(el)
+      const r = parseFloat(cs.borderTopLeftRadius) || 0
+      setTargetRadius(r)
     }
   }, [current.target])
 
@@ -56,26 +60,29 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
 
     if (current.scrollIntoView) {
       el.scrollIntoView({ behavior: "smooth", block: "center" })
-      let frame: number
-      const start = performance.now()
-      const poll = () => {
-        const r = el.getBoundingClientRect()
-        const inViewport = r.top >= 0 && r.bottom <= window.innerHeight
-        if (inViewport || performance.now() - start > 600) {
-          setRect(r)
-          setRectTarget(current.target)
-          hasScrolledRef.current = true
-        } else {
-          frame = requestAnimationFrame(poll)
-        }
+    }
+
+    // Poll rect for the full duration so CSS transitions (drawer slide, scroll, etc.)
+    // are tracked to completion rather than settling on the pre-transition rect.
+    let frame: number
+    const start = performance.now()
+    const DURATION = 500
+    const poll = () => {
+      const r = measureUnionRect(el)
+      setRect(r)
+      setRectTarget(current.target)
+      const cs = window.getComputedStyle(el)
+      const br = parseFloat(cs.borderTopLeftRadius) || 0
+      setTargetRadius(br)
+
+      if (performance.now() - start >= DURATION) {
+        hasScrolledRef.current = true
+        return
       }
       frame = requestAnimationFrame(poll)
-      return () => cancelAnimationFrame(frame)
-    } else {
-      setRect(el.getBoundingClientRect())
-      setRectTarget(current.target)
-      hasScrolledRef.current = true
     }
+    frame = requestAnimationFrame(poll)
+    return () => cancelAnimationFrame(frame)
   }, [current.target, current.scrollIntoView])
 
   // Reposition on resize/scroll (no scrollIntoView)
@@ -97,6 +104,15 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
     return () => observer.disconnect()
   }, [current.target, reposition])
 
+  // Reposition when subtree changes (e.g. dropdown opens inside target)
+  useEffect(() => {
+    const el = document.querySelector(`[data-onboarding="${current.target}"]`)
+    if (!el) return
+    const mo = new MutationObserver(reposition)
+    mo.observe(el, { childList: true, subtree: true, attributes: true })
+    return () => mo.disconnect()
+  }, [current.target, reposition])
+
   // Keyboard navigation
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -110,7 +126,7 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
   const ready = rect && rectTarget === current.target
 
   // On mobile, clamp the spotlight to the visible viewport so it doesn't extend off-screen
-  const padding = 8
+  const padding = isMobile ? 0 : 8
   const cutout = ready ? (() => {
     const vh = window.innerHeight
     const vw = window.innerWidth
@@ -132,10 +148,10 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
 
   const Icon = ICON_MAP[current.icon] ?? Search
 
-  // On mobile, dock tooltip to bottom; on desktop, position relative to element
+  // Anchor tooltip next to the spotlight on both mobile and desktop
   const tooltipStyle: React.CSSProperties = ready
     ? isMobile
-      ? {} // mobile uses bottom-docked layout via className
+      ? computeMobileTooltipStyle(current.mobilePosition, rect, 12)
       : computeTooltipPosition(current.tooltipPosition, rect)
     : {}
 
@@ -157,7 +173,7 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
           width: ready && cutout ? cutout.width : 0,
           height: ready && cutout ? cutout.height : 0,
           zIndex: 2001,
-          borderRadius: 12,
+          borderRadius: targetRadius + (isMobile ? 0 : padding),
           pointerEvents: "none",
         }}
       />
@@ -165,11 +181,7 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
       {/* Tooltip only renders when rect is measured for the current step */}
       {ready && cutout && (
         <div
-          className={`fixed z-[2002] ${
-            isMobile
-              ? "bottom-0 left-0 right-0 px-3 pb-3"
-              : ""
-          }`}
+          className="fixed z-[2002]"
           style={{
             ...tooltipStyle,
             ...(isMobile ? {} : { width: "min(340px, 90vw)" }),
@@ -250,6 +262,47 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
       )}
     </>
   )
+}
+
+// Returns the bounding box of the element, optionally extended by any
+// descendants marked with data-onboarding-include (e.g. absolutely-positioned
+// dropdowns). Keeps unrelated descendants (Leaflet tiles, etc.) from
+// inflating the rect.
+function measureUnionRect(el: Element): DOMRect {
+  const base = el.getBoundingClientRect()
+  let top = base.top
+  let left = base.left
+  let right = base.right
+  let bottom = base.bottom
+  el.querySelectorAll("[data-onboarding-include]").forEach((d) => {
+    const r = (d as Element).getBoundingClientRect()
+    if (r.width === 0 || r.height === 0) return
+    if (r.top < top) top = r.top
+    if (r.left < left) left = r.left
+    if (r.right > right) right = r.right
+    if (r.bottom > bottom) bottom = r.bottom
+  })
+  return new DOMRect(left, top, right - left, bottom - top)
+}
+
+function computeMobileTooltipStyle(
+  position: "top" | "bottom",
+  rect: DOMRect,
+  gap: number,
+): React.CSSProperties {
+  const vh = window.innerHeight
+  const side = 12
+  const estHeight = 180
+  if (position === "top" && rect.top < estHeight) {
+    return { top: rect.bottom + gap, left: side, right: side }
+  }
+  if (position === "bottom" && vh - rect.bottom < estHeight) {
+    return { bottom: vh - rect.top + gap, left: side, right: side }
+  }
+  if (position === "top") {
+    return { bottom: vh - rect.top + gap, left: side, right: side }
+  }
+  return { top: rect.bottom + gap, left: side, right: side }
 }
 
 function computeTooltipPosition(

--- a/app/components/onboarding/spotlight-overlay.tsx
+++ b/app/components/onboarding/spotlight-overlay.tsx
@@ -155,12 +155,62 @@ export function SpotlightOverlay({ step, onNext, onSkip, scheduledEventCount }: 
       : computeTooltipPosition(current.tooltipPosition, rect)
     : {}
 
+  const blockerTop = ready && cutout ? cutout.top : 0
+  const blockerLeft = ready && cutout ? cutout.left : 0
+  const blockerWidth = ready && cutout ? cutout.width : 0
+  const blockerHeight = ready && cutout ? cutout.height : 0
+  const swallow = (e: React.SyntheticEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }
+
   return (
     <>
-      {/* Backdrop always renders — no flash between steps */}
+      {/* Click blockers — four bars around the spotlight so everything except
+          the highlighted element is non-interactive while the tutorial is open. */}
       <div
-        className="fixed inset-0 z-[2000]"
-        style={{ pointerEvents: "none" }}
+        className="fixed left-0 right-0 top-0 z-[2000]"
+        style={{ height: Math.max(0, blockerTop), pointerEvents: "auto" }}
+        onClickCapture={swallow}
+        onPointerDownCapture={swallow}
+        onTouchStartCapture={swallow}
+      />
+      <div
+        className="fixed left-0 right-0 z-[2000]"
+        style={{
+          top: blockerTop + blockerHeight,
+          bottom: 0,
+          pointerEvents: "auto",
+        }}
+        onClickCapture={swallow}
+        onPointerDownCapture={swallow}
+        onTouchStartCapture={swallow}
+      />
+      <div
+        className="fixed z-[2000]"
+        style={{
+          top: blockerTop,
+          left: 0,
+          width: Math.max(0, blockerLeft),
+          height: blockerHeight,
+          pointerEvents: "auto",
+        }}
+        onClickCapture={swallow}
+        onPointerDownCapture={swallow}
+        onTouchStartCapture={swallow}
+      />
+      <div
+        className="fixed z-[2000]"
+        style={{
+          top: blockerTop,
+          left: blockerLeft + blockerWidth,
+          right: 0,
+          height: blockerHeight,
+          pointerEvents: "auto",
+        }}
+        onClickCapture={swallow}
+        onPointerDownCapture={swallow}
+        onTouchStartCapture={swallow}
       />
 
       {/* Spotlight always renders — 0x0 center fallback keeps box-shadow overlay visible between steps */}

--- a/app/components/onboarding/tutorial-steps.ts
+++ b/app/components/onboarding/tutorial-steps.ts
@@ -32,13 +32,13 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
     icon: "List",
     tooltipPosition: "right",
     scrollIntoView: false,
-    mobilePosition: "bottom",
+    mobilePosition: "top",
     requireInteraction: true,
     requiredScheduleCount: 2,
   },
   {
     id: "map-area",
-    target: "map-area",
+    target: "campus-map",
     title: "Campus Map & Schedule",
     description: "See where your events are on the campus map. Your schedule panel shows all added events with auto-generated walking routes between them.",
     icon: "Map",
@@ -54,6 +54,6 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
     icon: "Download",
     tooltipPosition: "left",
     scrollIntoView: true,
-    mobilePosition: "top",
+    mobilePosition: "bottom",
   },
 ]

--- a/app/components/schedule-panel.tsx
+++ b/app/components/schedule-panel.tsx
@@ -208,9 +208,8 @@ export function SchedulePanel({
 
           {/* Footer */}
           {scheduledEvents.length > 0 && (
-            <div className="p-3 border-t border-border relative">
+            <div data-onboarding="export-button" className="p-3 border-t border-border relative">
               <button
-                data-onboarding="export-button"
                 onClick={() => setShowExportMenu((v) => !v)}
                 disabled={isExporting}
                 className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-60"
@@ -221,7 +220,7 @@ export function SchedulePanel({
               </button>
 
               {showExportMenu && (
-                <div className="absolute left-3 right-3 mt-2 rounded-lg border border-border bg-card shadow-lg overflow-hidden z-10">
+                <div data-onboarding-include className="absolute left-3 right-3 mt-2 rounded-lg border border-border bg-card shadow-lg overflow-hidden z-10">
                   <button
                     onClick={() => { setShowExportMenu(false); onExportPdf(); }}
                     disabled={isExporting}

--- a/app/components/search-bar-section.tsx
+++ b/app/components/search-bar-section.tsx
@@ -233,17 +233,17 @@ export function SearchBarSection({
         )}
       </div>
 
-      {!mobile && (
-        <button
-          type="button"
-          onClick={onHelpClick}
-          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[#002D62] text-white transition-colors hover:bg-[#00244d]"
-          aria-label="Help"
-          title="Replay tutorial"
-        >
-          <HelpCircle className="h-5 w-5" strokeWidth={2} />
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={onHelpClick}
+        className={`flex shrink-0 items-center justify-center bg-[#002D62] text-white transition-colors hover:bg-[#00244d] ${
+          mobile ? "h-14 w-14 rounded-[18px]" : "h-12 w-12 rounded-xl"
+        }`}
+        aria-label="Help"
+        title="Replay tutorial"
+      >
+        <HelpCircle className="h-5 w-5" strokeWidth={2} />
+      </button>
     </div>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -102,16 +102,17 @@ button:disabled {
 /* Onboarding spotlight overlay */
 .onboarding-spotlight {
   box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.55);
-  border: 2px solid var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
   animation: spotlightPulse 1.5s ease-in-out infinite;
   transition: top 0.15s ease-out, left 0.15s ease-out, width 0.15s ease-out, height 0.15s ease-out;
 }
 
 @keyframes spotlightPulse {
   0%, 100% {
-    border-color: var(--accent);
+    outline-color: var(--accent);
   }
   50% {
-    border-color: var(--primary);
+    outline-color: var(--primary);
   }
 }


### PR DESCRIPTION
### Description of what has been done
- Map fills remaining mobile viewport
- Tooltip anchors beside spotlight on mobile
- Spotlight radius matches target element
- Export dropdown included in spotlight via opt-in attribute
- Export tooltip moved below button on mobile
- Freeze map interactions during PDF export
- Unify map step target across desktop/mobile
- Reset schedule when entering personalization
- Outline-based spotlight for flush element fit
- Info button beside mobile search bar to replay tutorial
- Drawer opens/closes per tutorial step

### Screenshots/Videos:
<img width="331" height="716" alt="image" src="https://github.com/user-attachments/assets/1468da08-b459-4bab-9876-aa9c8c096337" />
<img width="330" height="715" alt="image" src="https://github.com/user-attachments/assets/194462a2-8b0e-4dfb-a25d-ed292a1e590f" />
<img width="330" height="715" alt="image" src="https://github.com/user-attachments/assets/2af0435c-fb0e-4d4b-9a1d-12006f2f02ca" />



### Anything that still doesn't work? 

--

[x] I have updated the google doc as appropriate

Relevant issue to close or fix (type "Closes #X"): 
